### PR TITLE
Get user-detail based upon jwt-auth; passed serialized user-model-instance as response

### DIFF
--- a/authenticationApp/serializers.py
+++ b/authenticationApp/serializers.py
@@ -14,7 +14,6 @@ class UserSerializer(serializers.ModelSerializer):
             'password': {'write_only': True,},
         }
 
-
     def create(self, validated_data):
         """
         This method sits between the view & the user-model-creation

--- a/authenticationApp/urls.py
+++ b/authenticationApp/urls.py
@@ -1,7 +1,13 @@
 from django.urls import path
-from .views import RegisterView, LoginView
+
+from .views import (
+    RegisterView,
+    LoginView,
+    UserView,
+)
 
 urlpatterns = [
     path("register/", RegisterView.as_view(), name='register'),
     path("login/", LoginView.as_view(), name='login'),
+    path("user-detail/", UserView.as_view(), name='userDetail'),
 ]

--- a/dj_jwt_auth/settings.py
+++ b/dj_jwt_auth/settings.py
@@ -37,12 +37,16 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+
+    "rest_framework",
+    "corsheaders",  # without this, if the frontend has a different port than this django-app, it'll throw an error
     "authenticationApp.apps.AuthenticationappConfig",
 ]
 
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
@@ -133,3 +137,7 @@ STATIC_URL = "static/"
 # https://docs.djangoproject.com/en/4.1/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
+
+# Only for frontend usage
+CORS_ORIGIN_ALLOW_ALL = True
+CORS_ALLOW_CREDENTIALS = True   # [reason]: we login with cookie & return the cookie, otherwise, the frontend wouldn't be able to get the cookies


### PR DESCRIPTION
#Extra
- Implemented "**django-cors-headers**", so that the frontend can get the **jwt-auth-token** from the backend-API regardless of running on **different port**.